### PR TITLE
WIP: 维护常用活动地址及相关信息

### DIFF
--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -1,0 +1,8 @@
+nibaspace:
+  name: 泥巴创客空间
+  address: 西安市高新区科技路48号（科技路与高新四路十字西南角）创业广场C座
+  floor: 二楼
+  room: 8号会议室
+  map: http://greatghoul.b0.upaiyun.com/1508/dUDopnFKUkQBQ.png
+  parking: 创业广场停车厂
+  bus: 14路、221路


### PR DESCRIPTION
https://jekyllrb.com/docs/plugins/#tags

可以利用 jekyll 数据文件和自定义标签来实现方便的地址录入。

`data/locations.yml`

```
nibaspace:
  name: 泥巴创客空间
  address: 西安市高新区科技路48号（科技路与高新四路十字西南角）创业广场C座
  floor: 二楼
  room: 8号会议室
  map: http://greatghoul.b0.upaiyun.com/1508/dUDopnFKUkQBQ.png
  parking: 创业广场停车厂
  bus: 14路、221路
  photos:
   - photo1
   - photo2
   - photo3
   - photo4
```

```
{% render_location('nibaspace', { 'room': '6号会议室' }) %}
```

会先读取出 nibaspace 的配置，然后用提供的 `{ 'room': '6号会议室' }` 覆盖默认值，甚至可以放一些往期在这个会议室举办的活动的照片什么的。
